### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.rbc
 .bundle
 .config
+.swp
 .DS_Store
 .yardoc
 Gemfile.lock


### PR DESCRIPTION
Avoiding swp file extension which is usually generated by vim/macvim users.
